### PR TITLE
Add volume control via +/- keys

### DIFF
--- a/OMXPlayerAudio.cpp
+++ b/OMXPlayerAudio.cpp
@@ -714,6 +714,18 @@ void OMXPlayerAudio::SetCurrentVolume(long nVolume)
   if(m_decoder) m_decoder->SetCurrentVolume(nVolume);
 }
 
+long OMXPlayerAudio::GetCurrentVolume()
+{
+  if(m_decoder)
+  {
+    return m_decoder->GetCurrentVolume();
+  }
+  else
+  {
+    return 0;
+  }
+}
+
 void OMXPlayerAudio::SetSpeed(int speed)
 {
   m_speed = speed;

--- a/OMXPlayerAudio.h
+++ b/OMXPlayerAudio.h
@@ -128,6 +128,7 @@ public:
   void  UnRegisterAudioCallback();
   void  DoAudioWork();
   void SetCurrentVolume(long nVolume);
+  long GetCurrentVolume();
   void SetSpeed(int iSpeed);
   bool Error() { return !m_player_error; };
 };

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -555,6 +555,14 @@ int main(int argc, char *argv[])
           m_av_clock->OMXResume();
         }
         break;
+      case '-':
+        m_player_audio.SetCurrentVolume(m_player_audio.GetCurrentVolume() - 50);
+        printf("Current Volume: %.2fdB\n", m_player_audio.GetCurrentVolume() / 100.0f);
+        break;
+      case '=':
+        m_player_audio.SetCurrentVolume(m_player_audio.GetCurrentVolume() + 50);
+        printf("Current Volume: %.2fdB\n", m_player_audio.GetCurrentVolume() / 100.0f);
+        break;
       default:
         break;
     }


### PR DESCRIPTION
When running the HDMI output straight to a TV, the only means I have to raise the volume is to blast the TV's volume which results in very poor audio quality. The changes I made here to adjust the volume are working very well for me.
