### PR TITLE
Render subtitles to video overlay (not only to text console)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include Makefile.include
 
-CFLAGS+=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CMAKE_CONFIG -D__VIDEOCORE4__ -U_FORTIFY_SOURCE -Wall -DHAVE_OMXLIB -DUSE_EXTERNAL_FFMPEG  -DHAVE_LIBAVCODEC_AVCODEC_H -DHAVE_LIBAVUTIL_OPT_H -DHAVE_LIBAVUTIL_MEM_H -DHAVE_LIBAVUTIL_AVUTIL_H -DHAVE_LIBAVFORMAT_AVFORMAT_H -DHAVE_LIBAVFILTER_AVFILTER_H -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DTARGET_RASPBERRY_PI -DUSE_EXTERNAL_LIBBCM_HOST -Wno-psabi -I$(SDKSTAGE)/opt/vc/include/ 
+CFLAGS+=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CMAKE_CONFIG -D__VIDEOCORE4__ -U_FORTIFY_SOURCE -Wall -DHAVE_OMXLIB -DUSE_EXTERNAL_FFMPEG  -DHAVE_LIBAVCODEC_AVCODEC_H -DHAVE_LIBAVUTIL_OPT_H -DHAVE_LIBAVUTIL_MEM_H -DHAVE_LIBAVUTIL_AVUTIL_H -DHAVE_LIBAVFORMAT_AVFORMAT_H -DHAVE_LIBAVFILTER_AVFILTER_H -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DTARGET_RASPBERRY_PI -DUSE_EXTERNAL_LIBBCM_HOST -Wno-psabi -I$(SDKSTAGE)/opt/vc/include/ -I$(SDKSTAGE)/opt/vc/src/hello_pi/libs/vgfont
 
 LDFLAGS+=-L./ -lc -lWFC -lGLESv2 -lEGL -lbcm_host -lopenmaxil -Lffmpeg_compiled/usr/local/lib/
 INCLUDES+=-I./ -Ilinux -Iffmpeg_compiled/usr/local/include/
@@ -39,7 +39,7 @@ list_test:
 	$(CXX) -O3 -o list_test list_test.cpp
 
 omxplayer.bin: $(OBJS)
-	$(CXX) $(LDFLAGS) -o omxplayer.bin $(OBJS) -lvchiq_arm -lvcos -lrt -lpthread -lavutil -lavcodec -lavformat -lswscale -lpcre
+	$(CXX) $(LDFLAGS) -o omxplayer.bin $(OBJS) $(SDKSTAGE)/opt/vc/src/hello_pi/libs/vgfont/libvgfont.a -lvchiq_arm -lvcos -lrt -lpthread -lavutil -lavcodec -lavformat -lswscale -lpcre -lfreetype
 	#arm-unknown-linux-gnueabi-strip omxplayer.bin
 
 clean:
@@ -57,9 +57,9 @@ ffmpeg:
 
 dist: omxplayer.bin
 	mkdir -p omxplayer-dist/usr/lib/omxplayer
-	mkdir -p omxplayer-dist/usr/usr/bin
+	mkdir -p omxplayer-dist/usr/bin
 	mkdir -p omxplayer-dist/usr/share/doc
-	cp omxplayer omxplayer.bin omxplayer-dist/usr/usr/bin
+	cp omxplayer omxplayer.bin omxplayer-dist/usr/bin
 	cp COPYING omxplayer-dist/usr/share/doc/
 	cp README.md omxplayer-dist/usr/share/doc/README
 	cp -a ffmpeg_compiled/usr/local/lib/*.so* omxplayer-dist/usr/lib/omxplayer/


### PR DESCRIPTION
This is the test code to render subtitles to video overlay. 
Demo code from hello_font and library /opt/vc/src/hello_pi/libs/vgfont.
Issues:
- font does not support UTF8 (converted with iconv //TRANSLIT to ascii)
- video overlay only on 1/3 of screen (larger overlay does not work for me (probably CPU/GPU memory split issue))
- some shortcut can be added (font size, overlay position)
