### PR TITLE
Fix for issue #3, support non-square pixels

### DIFF
--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <algorithm>
 
 #ifndef STANDALONE
 #include "FileItem.h"
@@ -845,10 +846,8 @@ bool OMXReader::GetHints(AVStream *stream, COMXStreamInfo *hints)
       hints->fpsrate      = 0;
     }
 
-    if (stream->sample_aspect_ratio.num == 0)
-      hints->aspect = 0.0f;
-    else
-      hints->aspect = av_q2d(stream->sample_aspect_ratio) * stream->codec->width / stream->codec->height;
+    hints->pixel_x = std::max(0, stream->sample_aspect_ratio.num);
+    hints->pixel_y = std::max(0, stream->sample_aspect_ratio.den);
   }
 
   return true;

--- a/OMXStreamInfo.cpp
+++ b/OMXStreamInfo.cpp
@@ -51,7 +51,8 @@ void COMXStreamInfo::Clear()
   fpsrate  = 0;
   height   = 0;
   width    = 0;
-  aspect   = 0.0;
+  pixel_x  = 0;
+  pixel_y  = 0;
   vfr      = false;
   stills   = false;
   level    = 0;

--- a/OMXStreamInfo.h
+++ b/OMXStreamInfo.h
@@ -52,7 +52,8 @@ public:
   int fpsrate;
   int height; // height of the stream reported by the demuxer
   int width; // width of the stream reported by the demuxer
-  float aspect; // display aspect as reported by demuxer
+  unsigned int pixel_x; // relative width of a source pixel as reported by demuxer
+  unsigned int pixel_y; // relative height of a source pixel as reported by demuxer
   bool vfr; // variable framerate
   bool stills; // there may be odd still frames in video
   int level; // encoder level of the stream reported by the decoder. used to qualify hw decoders.

--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -570,11 +570,20 @@ bool COMXVideo::Open(COMXStreamInfo &hints, OMXClock *clock, bool deinterlace, b
   m_drop_state        = false;
   m_setStartTime      = true;
   m_setStartTimeText  = true;
-
-  /*
+  
   OMX_CONFIG_DISPLAYREGIONTYPE configDisplay;
   OMX_INIT_STRUCTURE(configDisplay);
   configDisplay.nPortIndex = m_omx_render.GetInputPort();
+
+  configDisplay.set      = OMX_DISPLAY_SET_PIXEL;
+  configDisplay.pixel_x  = hints.pixel_x;
+  configDisplay.pixel_y  = hints.pixel_y;
+
+  omx_err = m_omx_render.SetConfig(OMX_IndexConfigDisplayRegion, &configDisplay);
+  if(omx_err != OMX_ErrorNone)
+    return false;
+
+  /*
 
   configDisplay.set     = OMX_DISPLAY_SET_LAYER;
   configDisplay.layer   = 2;


### PR DESCRIPTION
Fix for issue #3. A simple test case:
https://docs.google.com/open?id=0B6NiJGv5WtHMMkd5UWhlU3dWVUk

This clip should appear narrow even though in pixel dimensions it is not.
