### PR TITLE
Fix for issue #45, player exits early

### DIFF
--- a/BitstreamConverter.h
+++ b/BitstreamConverter.h
@@ -157,7 +157,6 @@ protected:
   omx_bitstream_ctx m_sps_pps_context;
   bool              m_convert_bitstream;
   bool              m_to_annexb;
-  bool              m_convert_vc1;
 
   uint8_t           *m_extradata;
   int               m_extrasize;

--- a/OMXAudio.h
+++ b/OMXAudio.h
@@ -55,6 +55,7 @@ public:
   float GetDelay();
   float GetCacheTime();
   float GetCacheTotal();
+  unsigned int GetAudioRenderingLatency();
   COMXAudio();
   bool Initialize(IAudioCallback* pCallback, const CStdString& device, enum PCMChannels *channelMap,
                            COMXStreamInfo &hints, OMXClock *clock, EEncoded bPassthrough, bool bUseHWDecode);

--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -851,10 +851,12 @@ bool OMXReader::GetHints(AVStream *stream, COMXStreamInfo *hints)
       hints->fpsrate      = 0;
     }
 
-    if (stream->sample_aspect_ratio.num == 0)
-      hints->aspect = 0.0f;
-    else
+    if (stream->sample_aspect_ratio.num != 0)
       hints->aspect = av_q2d(stream->sample_aspect_ratio) * stream->codec->width / stream->codec->height;
+    else if (stream->codec->sample_aspect_ratio.num != 0)
+      hints->aspect = av_q2d(stream->codec->sample_aspect_ratio) * stream->codec->width / stream->codec->height;
+    else
+      hints->aspect = 0.0f;
   }
 
   return true;

--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -237,22 +237,15 @@ bool COMXVideo::Open(COMXStreamInfo &hints, OMXClock *clock, float display_aspec
       m_video_codec_name = "omx-vp8";
     break;
     case CODEC_ID_VC1:
+    case CODEC_ID_WMV3:
       // (role name) video_decoder.vc1
       // VC-1, WMV9
       decoder_name = OMX_VC1_DECODER;
       m_codingType = OMX_VIDEO_CodingWMV;
       m_video_codec_name = "omx-vc1";
-      break;
-    /*
-    case CODEC_ID_WMV3:
-      // (role name) video_decoder.wmv3
-      //WMV3
-      decoder_name = OMX_WMV3_DECODER;
-      m_codingType = OMX_VIDEO_CodingWMV;
-      m_video_codec_name = "omx-wmv3";
-      break;
-    */
+      break;    
     default:
+      printf("Vcodec id unknown: %x\n", hints.codec);
       return false;
     break;
   }
@@ -363,6 +356,9 @@ bool COMXVideo::Open(COMXStreamInfo &hints, OMXClock *clock, float display_aspec
 
   portParam.nPortIndex = m_omx_decoder.GetInputPort();
   portParam.nBufferCountActual = VIDEO_BUFFERS;
+
+  portParam.format.video.nFrameWidth  = m_decoded_width;
+  portParam.format.video.nFrameHeight = m_decoded_height;
 
   omx_err = m_omx_decoder.SetParameter(OMX_IndexParamPortDefinition, &portParam);
   if(omx_err != OMX_ErrorNone)

--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -1086,18 +1086,18 @@ void COMXVideo::WaitCompletion()
     return;
   }
 
-  clock_gettime(CLOCK_REALTIME, &starttime);
+  // clock_gettime(CLOCK_REALTIME, &starttime);
 
   while(true)
   {
     if(m_omx_render.IsEOS())
       break;
-    clock_gettime(CLOCK_REALTIME, &endtime);
-    if((endtime.tv_sec - starttime.tv_sec) > 5)
-    {
-      CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
-      break;
-    }
+    // clock_gettime(CLOCK_REALTIME, &endtime);
+    // if((endtime.tv_sec - starttime.tv_sec) > 5)
+    // {
+    //   CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
+    //   break;
+    // }
     OMXClock::OMXSleep(50);
   }
 


### PR DESCRIPTION
It turns out that audio_render sends EOS before it has played out all its buffers. So in addition, we need to wait for OMX_IndexConfigAudioRenderingLatency to reach zero before destroying.

I commented out the timeouts in WaitCompletion lest they may cut short pathological files. I will find time later to move this logic into the main loop so that it can be properly aborted by the user.
