### PR TITLE
Fix for issue #45, player exits early

### DIFF
--- a/OMXAudio.h
+++ b/OMXAudio.h
@@ -55,6 +55,7 @@ public:
   float GetDelay();
   float GetCacheTime();
   float GetCacheTotal();
+  unsigned int GetAudioRenderingLatency();
   COMXAudio();
   bool Initialize(IAudioCallback* pCallback, const CStdString& device, enum PCMChannels *channelMap,
                            COMXStreamInfo &hints, OMXClock *clock, EEncoded bPassthrough, bool bUseHWDecode);

--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -1086,18 +1086,18 @@ void COMXVideo::WaitCompletion()
     return;
   }
 
-  clock_gettime(CLOCK_REALTIME, &starttime);
+  // clock_gettime(CLOCK_REALTIME, &starttime);
 
   while(true)
   {
     if(m_omx_render.IsEOS())
       break;
-    clock_gettime(CLOCK_REALTIME, &endtime);
-    if((endtime.tv_sec - starttime.tv_sec) > 5)
-    {
-      CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
-      break;
-    }
+    // clock_gettime(CLOCK_REALTIME, &endtime);
+    // if((endtime.tv_sec - starttime.tv_sec) > 5)
+    // {
+    //   CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
+    //   break;
+    // }
     OMXClock::OMXSleep(50);
   }
 


### PR DESCRIPTION
It turns out that audio_render sends EOS before it has played out all its buffers. So in addition, we need to wait for OMX_IndexConfigAudioRenderingLatency to reach zero before destroying.

I commented out the timeouts in WaitCompletion lest they may cut short pathological files. I will find time later to move this logic into the main loop so that it can be properly aborted by the user.
