### PR TITLE
Don't boost on downmix

### DIFF
--- a/OMXAudio.cpp
+++ b/OMXAudio.cpp
@@ -110,7 +110,7 @@ COMXAudio::COMXAudio() :
   m_extrasize       (0      ),
   m_visBufferLength (0      ),
   m_last_pts        (DVD_NOPTS_VALUE),
-  m_boost_on_downmix(true   )
+  m_boost_on_downmix(false  )
 {
 }
 


### PR DESCRIPTION
After https://github.com/raspberrypi/firmware/commit/9f7cff the volume level is fine (even a tad louder than on my WDTV or with passthrough) without any boosting. Also, this could be related: https://github.com/raspberrypi/firmware/issues/96
