### PR TITLE
Removing alang to avoid confusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Using OMXPlayer
     Usage: omxplayer [OPTIONS] [FILE]
     Options :
              -h / --help                    print this help
-             -a / --alang language          audio language        : e.g. ger
              -n / --aidx  index             audio stream index    : e.g. 1
              -o / --adev  device            audio out device      : e.g. hdmi/local
              -i / --info                    dump stream format and exit

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -118,7 +118,7 @@ void print_usage()
   printf("Usage: omxplayer [OPTIONS] [FILE]\n");
   printf("Options :\n");
   printf("         -h / --help                    print this help\n");
-  printf("         -a / --alang language          audio language        : e.g. ger\n");
+//  printf("         -a / --alang language          audio language        : e.g. ger\n");
   printf("         -n / --aidx  index             audio stream index    : e.g. 1\n");
   printf("         -o / --adev  device            audio out device      : e.g. hdmi/local\n");
   printf("         -i / --info                    dump stream format and exit\n");


### PR DESCRIPTION
There are many people asking about --alang/-a at raspberry/raspbian irc channels, as it's not implemented I suggest removing in order to avoid confusions.
