### PR TITLE
Fix passthrough breakage and add boost-on-downmix flag.

### DIFF
--- a/IAudioRenderer.h
+++ b/IAudioRenderer.h
@@ -52,7 +52,7 @@ public:
 
   IAudioRenderer() {};
   virtual ~IAudioRenderer() {};
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int downmixChannels, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = ENCODED_NONE) = 0;
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int downmixChannels, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool boostOnDownmix, bool bIsMusic=false, EEncoded encoded = ENCODED_NONE) = 0;
   virtual void UnRegisterAudioCallback() = 0;
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) = 0;
   virtual float GetDelay() = 0;

--- a/OMXAudio.h
+++ b/OMXAudio.h
@@ -58,8 +58,8 @@ public:
   unsigned int GetAudioRenderingLatency();
   COMXAudio();
   bool Initialize(IAudioCallback* pCallback, const CStdString& device, enum PCMChannels *channelMap,
-                           COMXStreamInfo &hints, OMXClock *clock, EEncoded bPassthrough, bool bUseHWDecode);
-  bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int downmixChannels, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded bPassthrough = IAudioRenderer::ENCODED_NONE);
+                           COMXStreamInfo &hints, OMXClock *clock, EEncoded bPassthrough, bool bUseHWDecode, bool boostOnDownmix);
+  bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int downmixChannels, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool boostOnDownmix, bool bIsMusic=false, EEncoded bPassthrough = IAudioRenderer::ENCODED_NONE);
   ~COMXAudio();
 
   unsigned int AddPackets(const void* data, unsigned int len);
@@ -105,6 +105,7 @@ private:
   long          m_drc;
   bool          m_Passthrough;
   bool          m_HWDecode;
+  bool          m_normalize_downmix;
   unsigned int  m_BytesPerSec;
   unsigned int  m_BufferLen;
   unsigned int  m_ChunkLen;

--- a/OMXPlayerAudio.cpp
+++ b/OMXPlayerAudio.cpp
@@ -99,7 +99,8 @@ void OMXPlayerAudio::UnLockDecoder()
 }
 
 bool OMXPlayerAudio::Open(COMXStreamInfo &hints, OMXClock *av_clock, OMXReader *omx_reader,
-                          std::string device, bool passthrough, bool hw_decode, bool use_thread)
+                          std::string device, bool passthrough, bool hw_decode,
+                          bool boost_on_downmix, bool use_thread)
 {
   if(ThreadHandle())
     Close();
@@ -117,6 +118,7 @@ bool OMXPlayerAudio::Open(COMXStreamInfo &hints, OMXClock *av_clock, OMXReader *
   m_hw_decode   = false;
   m_use_passthrough = passthrough;
   m_use_hw_decode   = hw_decode;
+  m_boost_on_downmix = boost_on_downmix;
   m_iCurrentPts = DVD_NOPTS_VALUE;
   m_bAbort      = false;
   m_bMpeg       = m_omx_reader->IsMpegVideo();
@@ -612,7 +614,8 @@ bool OMXPlayerAudio::OpenDecoder()
     if(m_passthrough)
       m_hw_decode = false;
     bAudioRenderOpen = m_decoder->Initialize(NULL, m_device.substr(4), m_pChannelMap,
-                                             m_hints, m_av_clock, m_passthrough, m_hw_decode);
+                                             m_hints, m_av_clock, m_passthrough, 
+                                             m_hw_decode, m_boost_on_downmix);
   }
   else
   {
@@ -624,7 +627,7 @@ bool OMXPlayerAudio::OpenDecoder()
 
     bAudioRenderOpen = m_decoder->Initialize(NULL, m_device.substr(4), m_hints.channels, m_pChannelMap,
                                              downmix_channels, m_hints.samplerate, m_hints.bitspersample,
-                                             false, false, m_passthrough);
+                                             false, m_boost_on_downmix, false, m_passthrough);
   }
 
   m_codec_name = m_omx_reader->GetCodecName(OMXSTREAM_AUDIO);

--- a/OMXPlayerAudio.h
+++ b/OMXPlayerAudio.h
@@ -75,6 +75,7 @@ protected:
   bool                      m_use_hw_decode;
   IAudioRenderer::EEncoded  m_passthrough;
   bool                      m_hw_decode;
+  bool                      m_boost_on_downmix;
   bool                      m_bMpeg;
   bool                      m_bAbort;
   bool                      m_use_thread; 
@@ -108,7 +109,8 @@ public:
   OMXPlayerAudio();
   ~OMXPlayerAudio();
   bool Open(COMXStreamInfo &hints, OMXClock *av_clock, OMXReader *omx_reader,
-            std::string device, bool passthrough, bool hw_decode, bool use_thread);
+            std::string device, bool passthrough, bool hw_decode,
+            bool boost_on_downmix, bool use_thread);
   bool Close();
   bool Decode(OMXPacket *pkt);
   void Process();

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Using OMXPlayer
              -y / --hdmiclocksync           adjust display refresh rate to match video
              -t / --sid index               show subtitle with index
              -r / --refresh                 adjust framerate/resolution to video
+                  --boost-on-downmix        boost volume when downmixing
                   --font path               subtitle font
                                             (default: /usr/share/fonts/truetype/freefont/FreeSans.ttf)
                   --font-size size          font size as thousandths of screen height

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -91,6 +91,7 @@ bool              m_has_video           = false;
 bool              m_has_audio           = false;
 bool              m_has_subtitle        = false;
 float             m_display_aspect      = 0.0f;
+bool              m_boost_on_downmix    = false;
 
 enum{ERROR=-1,SUCCESS,ONEBYTE};
 
@@ -130,6 +131,7 @@ void print_usage()
   printf("         -y / --hdmiclocksync           adjust display refresh rate to match video\n");
   printf("         -t / --sid index               show subtitle with index\n");
   printf("         -r / --refresh                 adjust framerate/resolution to video\n");
+  printf("              --boost-on-downmix        boost volume when downmixing\n");
   printf("              --font path               subtitle font\n");
   printf("                                        (default: /usr/share/fonts/truetype/freefont/FreeSans.ttf)\n");
   printf("              --font-size size          font size as thousandths of screen height\n");
@@ -329,6 +331,8 @@ int main(int argc, char *argv[])
   double                startpts              = 0;
   TV_GET_STATE_RESP_T   tv_state;
 
+  const int boost_on_downmix_opt = 0x200;
+
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
     { "help",         no_argument,        NULL,          'h' },
@@ -345,6 +349,7 @@ int main(int argc, char *argv[])
     { "font",         required_argument,  NULL,          0x100 },
     { "font-size",    required_argument,  NULL,          0x101 },
     { "align",        required_argument,  NULL,          0x102 },
+    { "boost-on-downmix", no_argument,    NULL,          boost_on_downmix_opt },
     { 0, 0, 0, 0 }
   };
 
@@ -412,6 +417,9 @@ int main(int argc, char *argv[])
           m_centered = true;
         else
           m_centered = false;
+        break;
+      case boost_on_downmix_opt:
+        m_boost_on_downmix = true;
         break;
       case 0:
         break;
@@ -511,7 +519,8 @@ int main(int argc, char *argv[])
   m_omx_reader.GetHints(OMXSTREAM_AUDIO, m_hints_audio);
 
   if(m_has_audio && !m_player_audio.Open(m_hints_audio, m_av_clock, &m_omx_reader, deviceString, 
-                                         m_passthrough, m_use_hw_audio, m_thread_player))
+                                         m_passthrough, m_use_hw_audio,
+                                         m_boost_on_downmix, m_thread_player))
     goto do_exit;
 
   m_av_clock->SetSpeed(DVD_PLAYSPEED_NORMAL);


### PR DESCRIPTION
Because of some default arguments in IAudioRender::Initialize, an argument displacement in https://github.com/huceke/omxplayer/commit/ed58c7cdf3c5a1b38f07445e8da4bb995c8704f1 escaped me, breaking passthrough.
I discovered this while adding a boost-on-downmix flag for disabling normalization, so this commit contains that too.
