### PR TITLE
A small update to OMXReader.cpp to get file length (duration) into the output when omxplayer starts reading the file.

### DIFF
--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -246,8 +246,8 @@ bool OMXReader::Open(std::string filename, bool dump_format)
     }
   }
 
-  printf("file : %s result %d format %s audio streams %d video streams %d chapters %d subtitles %d\n", 
-      m_filename.c_str(), result, m_pFormatContext->iformat->name, m_audio_count, m_video_count, m_chapter_count, m_subtitle_count);
+  printf("file : %s result %d format %s audio streams %d video streams %d chapters %d subtitles %d length %d\n", 
+      m_filename.c_str(), result, m_pFormatContext->iformat->name, m_audio_count, m_video_count, m_chapter_count, m_subtitle_count, GetStreamLength() / 1000);
 
 
   m_speed       = DVD_PLAYSPEED_NORMAL;


### PR DESCRIPTION
Update OMXReader.cpp to get file length (duration) when omxplayer starts reading the file.
