### PR TITLE
Fix for streaming video from another application over a named pipe

### DIFF
--- a/File.cpp
+++ b/File.cpp
@@ -135,8 +135,14 @@ int CFile::Write(const void* lpBuf, int64_t uiBufSize)
 
 int CFile::IoControl(EIoControl request, void* param)
 {
-  if(request == IOCTRL_SEEK_POSSIBLE)
-    return 1;
+  if(request == IOCTRL_SEEK_POSSIBLE && m_pFile)
+  {
+    struct stat st;
+    if (fstat(fileno(m_pFile), &st) == 0)
+    {
+      return !S_ISFIFO(st.st_mode);
+    }
+  }
 
   return -1;
 }


### PR DESCRIPTION
CFile::IoControl(IOCTRL_SEEK_POSSIBLE) should only return true if the file provided is a regular file.
When binary video data is streamed from another application using a named pipe, it is not possible to seek, and data should be read sequentially.
