### PR TITLE
Fixed short option "-n" which causes "Segmentation Fault"

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -464,7 +464,7 @@ int main(int argc, char *argv[])
 
   int c;
   std::string mode;
-  while ((c = getopt_long(argc, argv, "wihnl:o:cslpd3:yzt:r", longopts, NULL)) != -1)  
+  while ((c = getopt_long(argc, argv, "wihn:l:o:cslpd3:yzt:r", longopts, NULL)) != -1)
   {
     switch (c) 
     {


### PR DESCRIPTION
The short option "-n" lacks parameter indicator ":" in getopt_long() so when you use it, it causes a "Segmentation Fault".
