### PR TITLE
Turned logging off and added a -g flag to enable logging

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -19,7 +19,7 @@ else
 fi
 
 if [ -e /usr/lib/omxplayer ]; then
-  export LD_LIBRARY_PATH=/opt/vc/lib:/usr/lib/omxplayer:$LD_LIBRARY_PATH 
+  export LD_LIBRARY_PATH=/opt/vc/lib:/usr/lib/omxplayer:$LD_LIBRARY_PATH
 else
   export LD_LIBRARY_PATH=$PWD/ffmpeg_compiled/usr/local/lib:/opt/vc/lib:$LD_LIBRARY_PATH
 fi
@@ -31,7 +31,7 @@ XRES=1600
 YRES=900
 
 if [ -e $FBSET ]; then
-  echo 0 >  /sys/class/vtconsole/vtcon1/bind
+  echo 0 > /sys/class/vtconsole/vtcon1/bind
   fbset -xres 1 -yres 1
 fi
 
@@ -39,5 +39,5 @@ $OMXPLAYER --font $FONT "$@"
 
 if [ -e $FBSET ]; then
   fbset -xres ${XRES} -yres ${YRES}
-  echo 1 >  /sys/class/vtconsole/vtcon1/bind
+  echo 1 > /sys/class/vtconsole/vtcon1/bind
 fi

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -101,6 +101,7 @@ bool              m_has_audio           = false;
 bool              m_has_subtitle        = false;
 float             m_display_aspect      = 0.0f;
 bool              m_boost_on_downmix    = false;
+bool              m_gen_log             = false;
 
 enum{ERROR=-1,SUCCESS,ONEBYTE};
 
@@ -141,6 +142,7 @@ void print_usage()
   printf("         -z / --nohdmiclocksync         do not adjust display refresh rate to match video\n");
   printf("         -t / --sid index               show subtitle with index\n");
   printf("         -r / --refresh                 adjust framerate/resolution to video\n");
+  printf("         -g / --genlog                  generate log file\n");
   printf("         -l / --pos                     start position (in seconds)\n");  
   printf("              --boost-on-downmix        boost volume when downmixing\n");
   printf("              --vol                     Set initial volume in millibels (default 0)\n");
@@ -279,8 +281,10 @@ void SetVideoMode(int width, int height, int fpsrate, int fpsscale, FORMAT_3D_T 
     num_modes = m_BcmHost.vc_tv_hdmi_get_supported_modes_new(group,
         supported_modes, max_supported_modes, &prefer_group, &prefer_mode);
 
+    if(m_gen_log) {
     CLog::Log(LOGDEBUG, "EGL get supported modes (%d) = %d, prefer_group=%x, prefer_mode=%x\n",
         group, num_modes, prefer_group, prefer_mode);
+    }
   }
 
   TV_SUPPORTED_MODE_NEW_T *tv_found = NULL;
@@ -457,6 +461,7 @@ int main(int argc, char *argv[])
     { "hdmiclocksync", no_argument,       NULL,          'y' },
     { "nohdmiclocksync", no_argument,     NULL,          'z' },
     { "refresh",      no_argument,        NULL,          'r' },
+    { "genlog",       no_argument,        NULL,          'g' },
     { "sid",          required_argument,  NULL,          't' },
     { "pos",          required_argument,  NULL,          'l' },    
     { "font",         required_argument,  NULL,          font_opt },
@@ -471,12 +476,15 @@ int main(int argc, char *argv[])
 
   int c;
   std::string mode;
-  while ((c = getopt_long(argc, argv, "wihn:l:o:cslpd3:yzt:r", longopts, NULL)) != -1)
+  while ((c = getopt_long(argc, argv, "wihn:l:o:cslpd3:yzt:rg", longopts, NULL)) != -1)
   {
     switch (c) 
     {
       case 'r':
         m_refresh = true;
+        break;
+      case 'g':
+        m_gen_log = true;
         break;
       case 'y':
         m_hdmi_clock_sync = true;
@@ -623,8 +631,13 @@ int main(int argc, char *argv[])
       m_has_external_subtitles = true;
     }
   }
-
-  CLog::Init("./");
+    
+  if(m_gen_log) {
+    CLog::SetLogLevel(LOG_LEVEL_DEBUG);
+    CLog::Init("./");
+  } else {
+    CLog::SetLogLevel(LOG_LEVEL_NONE);
+  }
 
   g_RBP.Initialize();
   g_OMX.Initialize();

--- a/utils/log.cpp
+++ b/utils/log.cpp
@@ -29,7 +29,7 @@ static FILE*       m_file           = NULL;
 static int         m_repeatCount    = 0;
 static int         m_repeatLogLevel = -1;
 static std::string m_repeatLine     = "";
-static int         m_logLevel       = LOG_LEVEL_DEBUG;
+static int         m_logLevel       = LOG_LEVEL_NONE;
 
 static pthread_mutex_t   m_log_mutex;
 
@@ -140,6 +140,7 @@ void CLog::Log(int loglevel, const char *format, ... )
 bool CLog::Init(const char* path)
 {
   pthread_mutex_init(&m_log_mutex, NULL);
+  if (m_logLevel > LOG_LEVEL_NONE) { 
   if (!m_file)
   {
     CStdString strLogFile, strLogFileOld;
@@ -163,12 +164,13 @@ bool CLog::Init(const char* path)
     unsigned char BOM[3] = {0xEF, 0xBB, 0xBF};
     fwrite(BOM, sizeof(BOM), 1, m_file);
   }
-
+  }
   return m_file != NULL;
 }
 
 void CLog::MemDump(char *pData, int length)
 {
+  if (m_logLevel > LOG_LEVEL_NONE) { 
   Log(LOGDEBUG, "MEM_DUMP: Dumping from %p", pData);
   for (int i = 0; i < length; i+=16)
   {
@@ -198,12 +200,14 @@ void CLog::MemDump(char *pData, int length)
     }
     Log(LOGDEBUG, "%s", strLine.c_str());
   }
+  }
 }
 
 void CLog::SetLogLevel(int level)
 {
+  if(m_logLevel > LOG_LEVEL_NONE)
+    CLog::Log(LOGNOTICE, "Log level changed to %d", m_logLevel);
   m_logLevel = level;
-  CLog::Log(LOGNOTICE, "Log level changed to %d", m_logLevel);
 }
 
 int CLog::GetLogLevel()
@@ -214,7 +218,9 @@ int CLog::GetLogLevel()
 void CLog::OutputDebugString(const std::string& line)
 {
 #if defined(_DEBUG) || defined(PROFILE)
+if(m_logLevel > LOG_LEVEL_NONE) {
   ::OutputDebugString(line.c_str());
   ::OutputDebugString("\n");
+}
 #endif
 }


### PR DESCRIPTION
The omxplayer.log writing every time omxplayer is run is inefficient and bad for the SD card. This fixes that but keeps the option of logging by adding a command line -g flag.

This could also be easily extended to detail the amount of logging.
