### PR TITLE
Deinitialize the clock

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1143,6 +1143,7 @@ do_exit:
 
   m_av_clock->OMXStop();
   m_av_clock->OMXStateIdle();
+  m_av_clock->Deinitialize();
 
   m_player_subtitles.Close();
   m_player_video.Close();


### PR DESCRIPTION
Without this, if the code is used as a base for a library (as in https://github.com/foufee/pi), the library hangs after around 80 to 100 plays, as it runs out of resources for creating the clock.
