### PR TITLE
Some minor improvements

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1069,7 +1069,7 @@ int main(int argc, char *argv[])
       static int count;
       if ((count++ & 15) == 0)
          printf("V : %8.02f %8d %8d A : %8.02f %8.02f/%8.02f Cv : %8d Ca : %8d                            \r",
-             m_av_clock->OMXMediaTime(), m_player_video.GetDecoderBufferSize(), m_player_video.GetDecoderFreeSpace(),
+             m_av_clock->OMXMediaTime() * 1e-6, m_player_video.GetDecoderBufferSize(), m_player_video.GetDecoderFreeSpace(),
              m_player_audio.GetCurrentPTS() / DVD_TIME_BASE - m_av_clock->OMXMediaTime() * 1e-6, m_player_audio.GetDelay(), m_player_audio.GetCacheTotal(),
              m_player_video.GetCached(), m_player_audio.GetCached());
     }

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1036,7 +1036,7 @@ int main(int argc, char *argv[])
 
       pts = m_av_clock->GetPTS();
 
-      seek_pos = (pts / DVD_TIME_BASE) + m_incr;
+      seek_pos =  (m_av_clock->OMXMediaTime() * 1e-6) + m_incr;
       seek_flags = m_incr < 0.0f ? AVSEEK_FLAG_BACKWARD : 0;
 
       seek_pos *= 1000.0f;


### PR DESCRIPTION
- Display the PTS stats output in seconds instead of nanoseconds.
- Also use OMXMediaTime for seek operations, to make a 30s seek really seek 30s instead of something like 37s.
