### PR TITLE
Adds pause/resume information on stdout

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -996,6 +996,7 @@ int main(int argc, char *argv[])
           m_av_clock->OMXPause();
           if(m_has_subtitle)
             m_player_subtitles.Pause();
+          printf("Player paused");
         }
         else
         {
@@ -1003,6 +1004,7 @@ int main(int argc, char *argv[])
             m_player_subtitles.Resume();
           SetSpeed(OMX_PLAYSPEED_NORMAL);
           m_av_clock->OMXResume();
+          printf("Player resumed");
         }
         break;
       case '-':


### PR DESCRIPTION
This commit makes omxplayer output status when paused is pressed. It allows external programs controlling omxplayer to check that pause/resume action has been applied and is handy when omxplayer is used from asynchronous code.
