### PR TITLE
Adds mute and direct sound settings keybindings

### DIFF
--- a/OMXAudio.cpp
+++ b/OMXAudio.cpp
@@ -39,10 +39,6 @@
 #include "guilib/LocalizeStrings.h"
 #endif
 
-#ifndef VOLUME_MINIMUM
-#define VOLUME_MINIMUM -6000  // -60dB
-#endif
-
 #include <algorithm>
 
 using namespace std;
@@ -118,6 +114,7 @@ COMXAudio::COMXAudio() :
   m_Pause           (false  ),
   m_CanPause        (false  ),
   m_CurrentVolume   (0      ),
+  m_LastVolume      (0      ),
   m_Passthrough     (false  ),
   m_HWDecode        (false  ),
   m_normalize_downmix(true   ),
@@ -222,6 +219,7 @@ bool COMXAudio::Initialize(IAudioCallback* pCallback, const CStdString& device, 
   m_CurrentVolume = g_settings.m_nVolumeLevel; 
 #else
   m_CurrentVolume = initialVolume;
+  m_LastVolume = m_CurrentVolume;
 #endif
 
   m_downmix_channels = downmixChannels;
@@ -731,10 +729,12 @@ void COMXAudio::Mute(bool bMute)
   if(!m_Initialized)
     return;
 
-  if (bMute)
+  if (bMute) {
+    m_LastVolume = m_CurrentVolume;
     SetCurrentVolume(VOLUME_MINIMUM);
+  }
   else
-    SetCurrentVolume(m_CurrentVolume);
+    SetCurrentVolume(m_LastVolume);
 }
 
 //***********************************************************************************************

--- a/OMXAudio.h
+++ b/OMXAudio.h
@@ -45,6 +45,10 @@
 
 #define VIS_PACKET_SIZE 3840
 
+#ifndef VOLUME_MINIMUM
+#define VOLUME_MINIMUM -6000  // -60dB
+#endif
+
 class COMXAudio : public IAudioRenderer
 {
 public:
@@ -101,6 +105,7 @@ private:
   bool          m_Pause;
   bool          m_CanPause;
   long          m_CurrentVolume;
+  long          m_LastVolume;
   long          m_drc;
   bool          m_Passthrough;
   bool          m_HWDecode;

--- a/OMXPlayerAudio.cpp
+++ b/OMXPlayerAudio.cpp
@@ -722,6 +722,11 @@ void OMXPlayerAudio::SetCurrentVolume(long nVolume)
   if(m_decoder) m_decoder->SetCurrentVolume(nVolume);
 }
 
+void OMXPlayerAudio::Mute(bool bMute)
+{
+  if(m_decoder) m_decoder->Mute(bMute);
+}
+
 long OMXPlayerAudio::GetCurrentVolume()
 {
   if(m_decoder)

--- a/OMXPlayerAudio.h
+++ b/OMXPlayerAudio.h
@@ -135,6 +135,7 @@ public:
   void  RegisterAudioCallback(IAudioCallback* pCallback);
   void  UnRegisterAudioCallback();
   void  DoAudioWork();
+  void Mute(bool bMute);
   void SetCurrentVolume(long nVolume);
   long GetCurrentVolume();
   void SetSpeed(int iSpeed);

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -190,6 +190,8 @@ void print_keybindings()
   printf("        p / space          pause/resume\n");
   printf("        -                  decrease volume\n");
   printf("        + / =              increase volume\n");
+  printf("        A - M              set volume between 0 and 120%% (per 10%% increments)\n");
+  printf("        *                  mute/unmute\n");
   printf("        left arrow         seek -30 seconds\n");
   printf("        right arrow        seek +30 seconds\n");
   printf("        down arrow         seek -600 seconds\n");
@@ -1011,6 +1013,26 @@ int main(int argc, char *argv[])
         break;
       case '+': case '=':
         m_player_audio.SetCurrentVolume(m_player_audio.GetCurrentVolume() + 300);
+        printf("Current Volume: %.2fdB\n", m_player_audio.GetCurrentVolume() / 100.0f);
+        break;
+      case '*':
+        // if volume is muted (i.e. at VOLUME_MINIMUM), we call Mute with false
+        // which unmutes sound, and vice-versa
+        m_player_audio.Mute(m_player_audio.GetCurrentVolume() != VOLUME_MINIMUM);
+        printf("Current Volume: %.2fdB\n", m_player_audio.GetCurrentVolume() / 100.0f);
+        break;
+      case 'A':
+        // 'A' is a special case since it would yield -inf
+        m_player_audio.SetCurrentVolume(VOLUME_MINIMUM);
+        printf("Current Volume: %.2fdB\n", m_player_audio.GetCurrentVolume() / 100.0f);
+        break;
+      case 'B': case 'C': case 'D': case 'E': case 'F': case 'G':
+      case 'H': case 'I': case 'J': case 'K': case 'L': case 'M':
+        // We make sound vary from -60dB to 6dB per 6dB increments
+        // We want dB from amplitude (0 - 120%) so we convert the sound as :
+        long mdb_vol;
+        mdb_vol = 2000.0 * log((float)(ch[0]-'A')/10);
+        m_player_audio.SetCurrentVolume(mdb_vol);
         printf("Current Volume: %.2fdB\n", m_player_audio.GetCurrentVolume() / 100.0f);
         break;
       default:


### PR DESCRIPTION
This patch adds a mute key ('*') so sound can me muted/unmuted.
It also provides keys from 'A' to 'M' that sets the sound level directly to a specific level between 0% and 120% (e.g. 'D' sets sounds to 30% volume, 'F' key to 50%, etc...). The formula used to convert between amplitude and dB maps 0% to -60dB (VOLUME_MINIMUM) and 100% to 0dB.

Those new keys should help omxplayer scripters around the world managing volume more efficiently.
